### PR TITLE
Fixed zussar api の読み取り間違いの修正

### DIFF
--- a/article/index.md
+++ b/article/index.md
@@ -68,7 +68,7 @@ template: index
                 </tr>
                     <tr>
                     <th>定員</th>
-                    <td><span id="tokyo-hokou-capacity-information"></span></td>
+                    <td><span id="tokyo-capacity-information"></span></td>
                 </tr>
                 <tr>
                     <th>会場</th>

--- a/index.html
+++ b/index.html
@@ -205,7 +205,7 @@
                 </tr>
                     <tr>
                     <th>定員</th>
-                    <td><span id="tokyo-hokou-capacity-information"></span></td>
+                    <td><span id="tokyo-capacity-information"></span></td>
                 </tr>
                 <tr>
                     <th>会場</th>


### PR DESCRIPTION
本講・補講の id名が重複していて、正常に動作していなかったので修正しました。