### PR TITLE
4会場表示でのレイアウト調整(CSS,HTML)

### DIFF
--- a/article/index.md
+++ b/article/index.md
@@ -127,7 +127,7 @@ template: index
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="https://perl-entrance-okinawa.connpass.com/">Perl入学式 in沖縄</a> 第1回</h4>
             <p class="date">
-                2016年4月22日（土）
+                2017年4月22日（土）
             </p>
             <div class="notice">
                 <!--次回の告知をお待ちください.-->
@@ -160,7 +160,7 @@ template: index
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="https://perl-entrance-sapporo.connpass.com/">Perl入学式 in札幌</a> 第1回</h4>
             <p class="date">
-                2016年4月15日（土）
+                2017年4月15日（土）
             </p>
             <div class="notice">
                 <a href = 'http://www.local.or.jp/about/students-transportation-expenses-support' target = '_blank'>LOCAL学生交通費支援制度</a>

--- a/article/index.md
+++ b/article/index.md
@@ -57,12 +57,14 @@ template: index
         </div>
     </div>
     <div class="row">
-        <div class="medium-4 large-6 columns ">
+        <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="http://perl-entrance-tokyo.connpass.com/">Perl入学式 in東京</a> 第1回</h4>
             <p class="date">
                 2017年4月22日（土）
-                <!--<span>次回の告知をお待ちください.</span>-->
             </p>
+            <div class="notice">
+                <!--次回の告知をお待ちください.-->
+            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -81,15 +83,21 @@ template: index
                     <td><a href="https://www.google.co.jp/maps?q=%E6%9D%B1%E4%BA%AC%E9%83%BD%E5%93%81%E5%B7%9D%E5%8C%BA%E8%A5%BF%E4%BA%94%E5%8F%8D%E7%94%B01-21-8+KSS%E4%BA%94%E5%8F%8D%E7%94%B0%E3%83%93%E3%83%AB6%E9%9A%8E+%E3%82%BB%E3%83%9F%E3%83%8A%E3%83%BC%E3%83%AB%E3%83%BC%E3%83%A01&zoom=17" target="_blank">東京都品川区西五反田1-21-8 KSS五反田ビル6階 セミナールーム1</a></td>
                 </tr>
             </table>
-            <p class="event-page"><a href="http://perl-entrance-tokyo.connpass.com/event/53584/" class="button radius expand" target="_blank">詳細はこちら!</a></p>
+            <div class="read-more">
+                <p class="event-page">
+                    <a href="http://perl-entrance-tokyo.connpass.com/event/53584/" class="button radius expand" target="_blank">詳細はこちら!</a>
+                </p>
+            </div>
         </div>
 
-        <div class="medium-4 large-6 columns ">
+        <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="http://perl-entrance-osaka.connpass.com/">Perl入学式 in大阪</a> 第5回</h4>
             <p class="date">
                 2017年1月21日（土）
-                <span>次回の告知をお待ちください.</span>
             </p>
+            <div class="notice">
+                次回の告知をお待ちください.
+            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -108,14 +116,22 @@ template: index
                     <td><a href="https://www.google.co.jp/maps?q=%E5%A4%A7%E9%98%AA%E5%BA%9C%E5%A4%A7%E9%98%AA%E5%B8%82%E5%8C%97%E5%8C%BA%E8%8A%9D%E7%94%B02%E4%B8%81%E7%9B%AE5%E2%88%926" target="_blank">大阪府大阪市北区芝田2丁目5−6</a></td>
                 </tr>
             </table>
-            <p class="event-page"><a href="http://perl-entrance-osaka.connpass.com/event/47105/" class="button radius expand" target="_blank">詳細はこちら!</a></p>
+            <div class="read-more">
+                <p class="event-page">
+                    <a href="http://perl-entrance-osaka.connpass.com/event/47105/" class="button radius expand" target="_blank">詳細はこちら!</a>
+                </p>
+            </div>
         </div>
-        <div class="medium-4 large-6 columns ">
+    </div>
+    <div class="row">
+        <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="https://perl-entrance-okinawa.connpass.com/">Perl入学式 in沖縄</a> 第1回</h4>
             <p class="date">
                 2016年4月22日（土）
-                <!--<span>次回の告知をお待ちください.</span>-->
             </p>
+            <div class="notice">
+                <!--次回の告知をお待ちください.-->
+            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -134,14 +150,22 @@ template: index
                     <td><a href="https://www.google.co.jp/maps?q=%E6%B2%96%E7%B8%84%E7%9C%8C%E4%B8%AD%E9%A0%AD%E9%83%A1%E8%A5%BF%E5%8E%9F%E7%94%BA%E5%8D%83%E5%8E%9F1%E7%95%AA%E5%9C%B0&zoom=17" target="_blank">沖縄県中頭郡西原町千原1番地</a></td>
                 </tr>
             </table>
-            <p class="event-page"><a href="https://perl-entrance-okinawa.connpass.com/event/53680/" class="button radius expand" target="_blank">詳細はこちら!</a></p>
+            <div class="read-more">
+                <p class="event-page">
+                    <a href="https://perl-entrance-okinawa.connpass.com/event/53680/" class="button radius expand" target="_blank">詳細はこちら!</a>
+                </p>
+            </div>
         </div>
-        <div class="medium-4 large-6 columns ">
+
+        <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> <a href="https://perl-entrance-sapporo.connpass.com/">Perl入学式 in札幌</a> 第1回</h4>
             <p class="date">
                 2016年4月15日（土）
-                <!-- <span>次回の告知をお待ちください.</span> -->
             </p>
+            <div class="notice">
+                <a href = 'http://www.local.or.jp/about/students-transportation-expenses-support' target = '_blank'>LOCAL学生交通費支援制度</a>
+                がご利用いただけます.
+            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -162,7 +186,11 @@ template: index
                     </td>
                 </tr>
             </table>
-            <p class="event-page"><a href="https://perl-entrance-sapporo.connpass.com/event/53585/" class="button radius expand" target="_blank">詳細はこちら!</a></p>
+            <div class="read-more">
+                <p class="event-page">
+                    <a href="https://perl-entrance-sapporo.connpass.com/event/53585/" class="button radius expand" target="_blank">詳細はこちら!</a>
+                </p>
+            </div>
         </div>
     </div>
 

--- a/article/index.md
+++ b/article/index.md
@@ -163,8 +163,10 @@ template: index
                 2017年4月15日（土）
             </p>
             <div class="notice">
+                <!--
                 <a href = 'http://www.local.or.jp/about/students-transportation-expenses-support' target = '_blank'>LOCAL学生交通費支援制度</a>
                 がご利用いただけます.
+                -->
             </div>
             <table class="detail">
                 <tr>

--- a/static/css/html.css
+++ b/static/css/html.css
@@ -356,13 +356,29 @@ header h5 {
 	font-weight: bold;
 }
 
-#homepage-event p.date {
-	font-size: 14px;
-	margin-bottom: 15px;
+#homepage-event .next-event {
+	height: 400px;
 }
 
-#homepage-event p.date span {
-	display: block;
+#homepage-event .read-more {
+    margin: 0;
+    padding: 0;
+	vertical-align: bottom;
+}
+
+#homepage-event .event-page {
+    margin: 0;
+}
+
+#homepage-event p.date {
+	font-size: 14px;
+    margin: 0;
+}
+
+#homepage-event div.notice {
+    height: 18px;
+    margin: 0 0 4px 0;
+    text-align: left;
 	color: #999;
 	font-size: 11px;
 }
@@ -379,7 +395,11 @@ header h5 {
 }
 
 #homepage-event table.detail th {
-	width: 25%;
+	width: 20%;
+	height: 44px;
+}
+#homepage-event table.detail td {
+	line-height: 1.3em;
 }
 
 @media screen and (min-width: 0px) and (max-width: 539px) {

--- a/static/css/html.css
+++ b/static/css/html.css
@@ -361,24 +361,24 @@ header h5 {
 }
 
 #homepage-event .read-more {
-    margin: 0;
-    padding: 0;
+	margin: 0;
+	padding: 0;
 	vertical-align: bottom;
 }
 
 #homepage-event .event-page {
-    margin: 0;
+	margin: 0;
 }
 
 #homepage-event p.date {
 	font-size: 14px;
-    margin: 0;
+	margin: 0;
 }
 
 #homepage-event div.notice {
-    height: 18px;
-    margin: 0 0 4px 0;
-    text-align: left;
+	height: 18px;
+	margin: 0 0 4px 0;
+	text-align: left;
 	color: #999;
 	font-size: 11px;
 }


### PR DESCRIPTION
以下の変更をしました

- 4会場が田の字に並ぶようにHTMLの調整(大阪と沖縄の間に`<div class = 'row'>`を入れて改行
- 各会場の詳細で使用されている要素・親要素に高さ(`height:`)を定義(青ボタン位置を揃えるため)
- ほかいろいろCSS調整
- 札幌に**LOCAL学生交通費支援制度**の記述を追加(コメントアウトした)
- 沖縄と札幌の開催日修正(2016 -> 2017)

![screen shot 2017-03-24 at 02 50 58](https://cloud.githubusercontent.com/assets/194955/24262322/076b5782-103d-11e7-9219-8686b87e6def.png)


ここまでやっておいてアレなんですが、Rijiを使っていないので、変更点に問題なければどなたかMergeしてうまいことHTML生成(?とかお願い致します。

