### PR TITLE
twitterのユーザータイムライン変更・廃止対応

### DIFF
--- a/index.html
+++ b/index.html
@@ -527,12 +527,7 @@
 <section id="homepage-twitter">
 <div class="row">
     <div class="small-6 large-6 columns">
-            <a class="twitter-timeline" href="https://twitter.com/Perl_Entrance" data-widget-id="490776177955442688">@Perl_Entrance からのツイート</a>
-            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </div>
-    <div class="small-6 large-6 columns">
-            <a class="twitter-timeline" href="https://twitter.com/hashtag/Perl%E5%85%A5%E5%AD%A6%E5%BC%8F" data-widget-id="490776027191185408">#Perl入学式件のツイート</a>
-            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+         <a class="twitter-timeline" data-lang="ja" data-height="750" href="https://twitter.com/Perl_Entrance?ref_src=twsrc%5Etfw">Tweets by Perl_Entrance</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
 </div>
 </section>

--- a/share/tmpl/index.tx
+++ b/share/tmpl/index.tx
@@ -37,12 +37,7 @@ Perl入学式 プログラミング初心者のためのPerl入門講座
 <section id="homepage-twitter">
 <div class="row">
     <div class="small-6 large-6 columns">
-            <a class="twitter-timeline" href="https://twitter.com/Perl_Entrance" data-widget-id="490776177955442688">@Perl_Entrance からのツイート</a>
-            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
-    </div>
-    <div class="small-6 large-6 columns">
-            <a class="twitter-timeline" href="https://twitter.com/hashtag/Perl%E5%85%A5%E5%AD%A6%E5%BC%8F" data-widget-id="490776027191185408">#Perl入学式件のツイート</a>
-            <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+         <a class="twitter-timeline" data-lang="ja" data-height="750" href="https://twitter.com/Perl_Entrance?ref_src=twsrc%5Etfw">Tweets by Perl_Entrance</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
     </div>
 </div>
 </section>


### PR DESCRIPTION
ユーザータイムラインは取得可能だが、ハッシュタグのタイムラインは取得できない模様
[タイムラインを埋め込む方法](https://help.twitter.com/ja/using-twitter/embed-twitter-feed)

Chromeにて以下の警告が出ており、ハッシュタグのタイムラインはすでに表示されていない状態だった
> You may have been affected by an update to settings in embedded timelines

ユーザータイムラインは新ウィジットに変更し、ハッシュタグのタイムラインは削除した