### PR TITLE
Copyright 表記の年表記は発行年のみの表記にする

### DIFF
--- a/share/tmpl/base.tx
+++ b/share/tmpl/base.tx
@@ -18,7 +18,7 @@
     <meta property="og:site_name" content="<: $blog.title :>" />
     <meta property="og:email" content="webmaster@perl-entrance.org" />
     <meta name="author" content="<: $blog.author :>" />
-    <meta name="copyright" content="(c) 2012-2018 Perl Entrance, Japan Perl Association" />
+    <meta name="copyright" content="(c) 2012 Perl Entrance, Japan Perl Association" />
     <link type="text/css" rel="stylesheet" href="<: '/static/css/style.css' | uri_for :>" />
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
     <script src="<: '/static/js/foundation.min.js' | uri_for :>"></script>
@@ -129,7 +129,7 @@
             </ul>
         </div>
         <div class="medium-8 medium-8 pull-4 columns">
-            <address>&copy; 2012-2019 Perl Entrance, <a href="http://japan.perlassociation.org/">Japan Perl Association</a></address>
+            <address>&copy; 2012 Perl Entrance, <a href="http://japan.perlassociation.org/">Japan Perl Association</a></address>
         </div>
     </div>
 </div><!--  / #footer /  -->


### PR DESCRIPTION
Copyright の年表記が 2012-2019 のようなところを 2012-2020 にしようとしたのですが、そもそも不要ではということもあり、控えめに発行年の 2012 のみにしようと考えています。

- 参考：[GoogleやYahoo! JAPANでさえ間違ってる、Copyright（コピーライト） の正しい書き方 - 2016年版 | hajipion.com](https://hajipion.com/2288.html)

ブランチ上で `riji publish` すると

```
You need at publish branch [master], so `git checkout master` beforehand or you can use --force option
```

といった警告が出てくるため、とりあえずテンプレートファイルのみの変更にとどめています。

ご意見ありましたら、この Pull Request でお気軽にお寄せ下さい。