### PR TITLE
2020年第1回の講義資料に動画やスライドリンクを追加

### DIFF
--- a/article/handout.md
+++ b/article/handout.md
@@ -23,6 +23,8 @@ title: 講義資料
                     <h4 class="subheader">#1</h4>
                     <p>
 <a href="https://github.com/perl-entrance-org/workshop-basic-online/blob/master/1st/slide.md">資料</a>
+（<a href="https://appslideshare.tugougaii.site/slide/Online2020?p=1&c=pre-left&cf=1">スライド</a>）
+/ <a href="https://www.youtube.com/watch?v=ZUTdDaIsyNc">講義動画</a>
 / <a href="https://github.com/perl-entrance-org/workshop-basic-online/tree/master/1st/answer">練習問題の解答例</a>
                     </p>
                     <h2 id="handout-2019">2019年度 <small>Perl Entrance 2019</small></h2>

--- a/article/handout.md
+++ b/article/handout.md
@@ -20,7 +20,7 @@ title: 講義資料
                         Perl入学式が提供する全ての資料のライセンスについては, <a href="<: '/license.html' | uri_for :>">ライセンス</a>のページからご確認下さい.
                     </p>
                     <h2 id="handout-2020">2020年度 <small>Perl Entrance 2020</small></h2>
-                    <h4 class="subheader">#1</h4>
+                    <h4 class="subheader"><a href="https://perl-entrance.connpass.com/event/189331/">#1</a></h4>
                     <p>
 <a href="https://github.com/perl-entrance-org/workshop-basic-online/blob/master/1st/slide.md">資料</a>
 （<a href="https://appslideshare.tugougaii.site/slide/Online2020?p=1&c=pre-left&cf=1">スライド</a>）


### PR DESCRIPTION
講義動画をアーカイブ公開しているので、後で資料を振り返る際にすぐ講義動画を参照できた方が良いのではということでリンクを追加してみました。

ついでにスライド同期くんのリンクも追加。

検討事項として、2020年度からは年度を越えて1個のリポジトリを使うことにしたので、その GitHub へのリンク先ある資料はその時点での HEAD であって講義時点のものではないという若干の問題がありそう。これを解決するのであれば、特定のコミットIDやタグをリンクとする必要があり、これは perl-entrance-org/workshop-basic-online#55 で議論することになりそう。

大丈夫そうであれば、マージの前に `riji publish` することを忘れずに。