### PR TITLE
日付を見て自動的に「次回の告知をお待ち下さい」を表示する

### DIFF
--- a/article/index.md
+++ b/article/index.md
@@ -55,12 +55,9 @@ template: index
         <!-- オンライン -->
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> Perl入学式 オンライン 第1回</h4>
-            <p class="date">
+            <p class="date" data-date="2022-05-21T00:00:00+09:00">
                 <del style="color: lightgray; text-decoration:line-through;">2022年5月21日（土）</del> 延期となりました
             </p>
-            <div class="notice">
-                次回の告知をお待ちください
-            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -88,7 +85,7 @@ template: index
         <!-- 東京 -->
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> Perl入学式 in東京 第1回</h4>
-            <p class="date">
+            <p class="date" data-date="2022-05-28T00:00:00+09:00">
                 2022年5月28日（土）
             </p>
             <!--

--- a/index.html
+++ b/index.html
@@ -208,12 +208,9 @@
         <!-- オンライン -->
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> Perl入学式 オンライン 第1回</h4>
-            <p class="date">
+            <p class="date" data-date="2022-05-21T00:00:00+09:00">
                 <del style="color: lightgray; text-decoration:line-through;">2022年5月21日（土）</del> 延期となりました
             </p>
-            <div class="notice">
-                次回の告知をお待ちください
-            </div>
             <table class="detail">
                 <tr>
                     <th>時間</th>
@@ -241,7 +238,7 @@
         <!-- 東京 -->
         <div class="medium-6 large-6 columns next-event">
             <h4><i class="icon-leaf"></i> Perl入学式 in東京 第1回</h4>
-            <p class="date">
+            <p class="date" data-date="2022-05-28T00:00:00+09:00">
                 2022年5月28日（土）
             </p>
             <!--

--- a/share/static/js/functions.js
+++ b/share/static/js/functions.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
 		}
 		// 次回開催日が今日よりも過去である場合は次回告知をしていないので、その旨を表示する
 		if (nextEventDate < now){
-			$dateDom.append('<div class="notice">次回の告知をお待ちください</div>');
+			$dateDom.after('<div class="notice">次回の告知をお待ちください</div>');
 		}
 	});
 })

--- a/share/static/js/functions.js
+++ b/share/static/js/functions.js
@@ -52,6 +52,27 @@ function wait(ms) {
 	};
 }
 
+// 日付を見て自動的に告知メッセージを表示する
+// https://github.com/perl-entrance-org/perl-entrance-org.github.com/issues/93
+$(document).ready(function() {
+	"use strict";
+	const now = new Date().toLocaleString({ timeZone: 'Asia/Tokyo' });
+	$('.date').each((_, dateDom) => {
+		const $dateDom = $(dateDom);
+		const nextEventDate = $dateDom.data('date') !== undefined ? 
+			new Date($dateDom.data('date')).toLocaleDateString({ timeZone: 'Asia/Tokyo'})
+			: undefined;
+
+		if (!nextEventDate) {
+			return;
+		}
+		// 次回開催日が今日よりも過去である場合は次回告知をしていないので、その旨を表示する
+		if (nextEventDate < now){
+			$dateDom.append('<div class="notice">次回の告知をお待ちください</div>');
+		}
+	});
+})
+
 // Connpass
 $(document).ready(function() {
 	"use strict";

--- a/share/static/js/functions.js
+++ b/share/static/js/functions.js
@@ -57,8 +57,7 @@ function wait(ms) {
 $(document).ready(function() {
 	"use strict";
 	const now = new Date().toLocaleString({ timeZone: 'Asia/Tokyo' });
-	$('.date').each((_, dateDom) => {
-		const $dateDom = $(dateDom);
+	$('.date').map((_,dataDom) => $(dataDom)).each((_, $dateDom) => {
 		const nextEventDate = $dateDom.data('date') !== undefined ? 
 			new Date($dateDom.data('date')).toLocaleDateString({ timeZone: 'Asia/Tokyo'})
 			: undefined;

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -68,7 +68,7 @@ $(document).ready(function() {
 		}
 		// 次回開催日が今日よりも過去である場合は次回告知をしていないので、その旨を表示する
 		if (nextEventDate < now){
-			$dateDom.append('<div class="notice">次回の告知をお待ちください</div>');
+			$dateDom.after('<div class="notice">次回の告知をお待ちください</div>');
 		}
 	});
 })

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -52,6 +52,27 @@ function wait(ms) {
 	};
 }
 
+// 日付を見て自動的に告知メッセージを表示する
+// https://github.com/perl-entrance-org/perl-entrance-org.github.com/issues/93
+$(document).ready(function() {
+	"use strict";
+	const now = new Date().toLocaleString({ timeZone: 'Asia/Tokyo' });
+	$('.date').each((_, dateDom) => {
+		const $dateDom = $(dateDom);
+		const nextEventDate = $dateDom.data('date') !== undefined ? 
+			new Date($dateDom.data('date')).toLocaleDateString({ timeZone: 'Asia/Tokyo'})
+			: undefined;
+
+		if (!nextEventDate) {
+			return;
+		}
+		// 次回開催日が今日よりも過去である場合は次回告知をしていないので、その旨を表示する
+		if (nextEventDate < now){
+			$dateDom.append('<div class="notice">次回の告知をお待ちください</div>');
+		}
+	});
+})
+
 // Connpass
 $(document).ready(function() {
 	"use strict";

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -57,8 +57,7 @@ function wait(ms) {
 $(document).ready(function() {
 	"use strict";
 	const now = new Date().toLocaleString({ timeZone: 'Asia/Tokyo' });
-	$('.date').each((_, dateDom) => {
-		const $dateDom = $(dateDom);
+	$('.date').map((_,dataDom) => $(dataDom)).each((_, $dateDom) => {
 		const nextEventDate = $dateDom.data('date') !== undefined ? 
 			new Date($dateDom.data('date')).toLocaleDateString({ timeZone: 'Asia/Tokyo'})
 			: undefined;


### PR DESCRIPTION
ref: https://github.com/perl-entrance-org/perl-entrance-org.github.com/issues/93

自動表示対応です。

## やったこと
- DOMの文字列パースはそれはそれで大変なので、(Perlならしますが...)`class="date"`の後ろにdata属性で日付を入れるようにしました
  - ISO 8601想定です
  - 日付入れる箇所が増えましたがまぁ一箇所なので大丈夫かな + 逆に日本語文字列表記の方をdata属性から出すのもできると思うので....
- 読み込み時にdata classのものを一通り舐めて、data-dateの有無、及び過去かどうかをチェックするようにしました
- 過去だった場合jQueryでDOMを操作して告知をいれるようにしました