### PR TITLE
connpass API の結果 JSON が持つ events 配列がカラだったときのフォールバック処理を追加

### DIFF
--- a/share/static/js/functions.js
+++ b/share/static/js/functions.js
@@ -109,7 +109,7 @@ $(document).ready(function() {
 		var r = json.events[0];
 		var $container = this.get_info_container();
 		// waiting: 補欠者, accepted: 参加者, limit: 定員
-		if ( [r.waiting, r.accepted, r.limit].every(function(x){return typeof x !== "undefined"}) ) {
+		if ( r && [r.waiting, r.accepted, r.limit].every(function(x){return typeof x !== "undefined"}) ) {
 			var description = (r.limit ? r.limit + "人" : "定員無し") + " (現在" + r.accepted + "名参加, " + r.waiting + "名補欠)";
 			$container.html(description);
 		} else {

--- a/share/static/js/functions.js
+++ b/share/static/js/functions.js
@@ -113,7 +113,7 @@ $(document).ready(function() {
 			var description = (r.limit ? r.limit + "人" : "定員無し") + " (現在" + r.accepted + "名参加, " + r.waiting + "名補欠)";
 			$container.html(description);
 		} else {
-			$container.html("(データ取得ができませんでした)");
+			$container.html("<span style='color: lightgray'>(データ取得ができませんでした)</span>");
 		}
 	};
 

--- a/static/js/functions.js
+++ b/static/js/functions.js
@@ -109,11 +109,11 @@ $(document).ready(function() {
 		var r = json.events[0];
 		var $container = this.get_info_container();
 		// waiting: 補欠者, accepted: 参加者, limit: 定員
-		if ( [r.waiting, r.accepted, r.limit].every(function(x){return typeof x !== "undefined"}) ) {
+		if ( r && [r.waiting, r.accepted, r.limit].every(function(x){return typeof x !== "undefined"}) ) {
 			var description = (r.limit ? r.limit + "人" : "定員無し") + " (現在" + r.accepted + "名参加, " + r.waiting + "名補欠)";
 			$container.html(description);
 		} else {
-			$container.html("(データ取得ができませんでした)");
+			$container.html("<span style='color: lightgray'>(データ取得ができませんでした)</span>");
 		}
 	};
 


### PR DESCRIPTION
タイトルの通りです。もともと if で書いていたつもりだったけれど、もう一押し必要でした……。今度は手元で無効な event_id にした上で表示を確認したので大丈夫なはず。

特に懸念コメントなければ、明日あたりにマージします。

Issue は #102