### PR TITLE
YouTube チャンネルへのリンクをハンドルを使用したものに変更

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,7 +40,7 @@
     <ul class="off-canvas-list">
         <li><a href="/about.html"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -85,7 +85,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="/handout.html" class=""><i class="icon-document-text"></i> 講義資料</a>

--- a/calendar.html
+++ b/calendar.html
@@ -40,7 +40,7 @@
     <ul class="off-canvas-list">
         <li><a href="/about.html"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -85,7 +85,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="/handout.html" class=""><i class="icon-document-text"></i> 講義資料</a>

--- a/handout.html
+++ b/handout.html
@@ -40,7 +40,7 @@
     <ul class="off-canvas-list">
         <li><a href="/about.html"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -85,7 +85,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="/handout.html" class=""><i class="icon-document-text"></i> 講義資料</a>

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     <ul class="off-canvas-list">
         <li><a href="/about.html"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -85,7 +85,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="/handout.html" class=""><i class="icon-document-text"></i> 講義資料</a>

--- a/license.html
+++ b/license.html
@@ -40,7 +40,7 @@
     <ul class="off-canvas-list">
         <li><a href="/about.html"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -85,7 +85,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="/handout.html" class=""><i class="icon-document-text"></i> 講義資料</a>

--- a/share/tmpl/base.tx
+++ b/share/tmpl/base.tx
@@ -39,7 +39,7 @@
     <ul class="off-canvas-list">
         <li><a href="<: '/about.html' | uri_for :>"><i class="icon-world"></i> Perl入学式とは</a></li>
         <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
-        <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
+        <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i> YouTubeチャンネル</a></li>
     </ul>
     <ul class="off-canvas-list">
         <li><label> 講義資料</label></li>
@@ -84,7 +84,7 @@
             <li class="divider"></li>
             <li><a href="http://blog.perl-entrance.org/" target="_blank"><i class="icon-news"></i> 公式ブログ</a></li>
             <li class="divider"></li>
-            <li><a href="https://www.youtube.com/channel/UCD-vSGHhhcHMgjMJEoAX99Q/" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
+            <li><a href="https://www.youtube.com/@Perl_Entrance" target="_blank"><i class="icon-news"></i>YouTubeチャンネル</a></li>
             <li class="divider"></li>
             <li class="has-dropdown">
                 <a href="<: '/handout.html' | uri_for :>" class=""><i class="icon-document-text"></i> 講義資料</a>


### PR DESCRIPTION
タイトルの通りですが、YouTube チャンネルへのリンクを昨年取得したハンドルを使用したものに変更しました。リンク先等の機能面では変更ありませんが、覚えやすいリンクになったかと思います。