### PR TITLE
GA4 (Google Analytics 4) 対応

### DIFF
--- a/about.html
+++ b/about.html
@@ -245,6 +245,7 @@ Discord : <a href="https://discord.gg/2QNqVyk">チャット招待</a><br>
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -263,6 +264,16 @@ Discord : <a href="https://discord.gg/2QNqVyk">チャット招待</a><br>
     ga('create', 'UA-53612303-1', 'auto');
     ga('send', 'pageview');
   }
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
 </script>
 
 </body>

--- a/calendar.html
+++ b/calendar.html
@@ -170,6 +170,7 @@
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -188,6 +189,16 @@
     ga('create', 'UA-53612303-1', 'auto');
     ga('send', 'pageview');
   }
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
 </script>
 
 </body>

--- a/handout.html
+++ b/handout.html
@@ -497,6 +497,7 @@
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -515,6 +516,16 @@
     ga('create', 'UA-53612303-1', 'auto');
     ga('send', 'pageview');
   }
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
 </script>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -389,6 +389,7 @@
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -407,6 +408,16 @@
     ga('create', 'UA-53612303-1', 'auto');
     ga('send', 'pageview');
   }
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
 </script>
 
 </body>

--- a/license.html
+++ b/license.html
@@ -204,6 +204,7 @@
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
@@ -222,6 +223,16 @@
     ga('create', 'UA-53612303-1', 'auto');
     ga('send', 'pageview');
   }
+</script>
+
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
 </script>
 
 </body>

--- a/share/tmpl/base.tx
+++ b/share/tmpl/base.tx
@@ -147,6 +147,7 @@
 </div><!--  / .off-canvas-wrap /  -->
 
 <script>
+  // TODO: GA4 以前の UA（= Universal Analytics、または GA3） のタグ。UA 終了後に消す
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
   (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
   m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)

--- a/share/tmpl/base.tx
+++ b/share/tmpl/base.tx
@@ -167,5 +167,15 @@
   }
 </script>
 
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-VG21GT84ES"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-VG21GT84ES');
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
今まで使っていた UA (Universal Analytics, GA3) が崩壊していたので、GA4 の設定をしてみました。

いったん UA が完全終了する2024年夏くらいまでは UA のタグも残して置こうかなと考えています。